### PR TITLE
Allow Errors in Queue Tasks to reject Promise

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -133,7 +133,6 @@
      */
     Queue.prototype._dequeue = function () {
         var self = this;
-
         if (this.pendingPromises >= this.maxPendingPromises) {
             return false;
         }
@@ -146,26 +145,30 @@
 
         try {
             this.pendingPromises++;
+
             resolveWith(item.promiseGenerator())
             // Forward all stuff
                 .then(function (value) {
                     // It is not pending now
                     self.pendingPromises--;
-                    self._dequeue();
                     // It should pass values
                     item.resolve(value);
+                    self._dequeue();
                 }, function (err) {
                     // It is not pending now
                     self.pendingPromises--;
-                    self._dequeue();
                     // It should not mask errors
                     item.reject(err);
+                    self._dequeue();
                 }, function (message) {
                     // It should pass notifications
                     item.notify(message);
                 });
         } catch (err) {
+            self.pendingPromises--;
             item.reject(err);
+            self._dequeue();
+
         }
 
         return true;

--- a/lib/index.js
+++ b/lib/index.js
@@ -144,29 +144,30 @@
             return false;
         }
 
-        this.pendingPromises++;
-        resolveWith(item.promiseGenerator())
+        try {
+            this.pendingPromises++;
+            resolveWith(item.promiseGenerator())
             // Forward all stuff
-            .then(function (value) {
-                // It is not pending now
-                self.pendingPromises--;
-                self._dequeue();
-                // It should pass values
-                item.resolve(value);
-            }, function (err) {
-                // It is not pending now
-                self.pendingPromises--;
-                self._dequeue();
-                // It should not mask errors
-                item.reject(err);
-            }, function (message) {
-                // It should pass notifications
-                item.notify(message);
-            }).then(noop, function(error) {
-            // If there is an error that is raised in the above
-            // handler, we relay it the main promise.
-            item.reject(error);
-        });
+                .then(function (value) {
+                    // It is not pending now
+                    self.pendingPromises--;
+                    self._dequeue();
+                    // It should pass values
+                    item.resolve(value);
+                }, function (err) {
+                    // It is not pending now
+                    self.pendingPromises--;
+                    self._dequeue();
+                    // It should not mask errors
+                    item.reject(err);
+                }, function (message) {
+                    // It should pass notifications
+                    item.notify(message);
+                });
+        } catch (err) {
+            item.reject(err);
+        }
+
         return true;
     };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -162,8 +162,11 @@
             }, function (message) {
                 // It should pass notifications
                 item.notify(message);
-            });
-
+            }).then(noop, function(error) {
+            // If there is an error that is raised in the above
+            // handler, we relay it the main promise.
+            item.reject(error);
+        });
         return true;
     };
 

--- a/test/test.queue.js
+++ b/test/test.queue.js
@@ -260,7 +260,7 @@ describe('queue', function () {
     describe('getPendingLength', function () {
 
         it('returns number of pending promises', function (done) {
-            var expectedPendingLength = 10;
+            var expectedPendingLength = 9;
             var pendingNumber = 10;
             var queue = new Queue(expectedPendingLength);
 
@@ -287,6 +287,7 @@ describe('queue', function () {
 
             // Note: extra promises will be moved to a queue
             for (var i = 0; i < expectedPendingLength * 2; i++) {
+                // Check is after the first item is complete, so it should always be one less.
                 queue.add(generator()).then(check).then(null, done);
             }
 
@@ -315,6 +316,7 @@ describe('queue', function () {
 
             function check() {
                 expectedQueueLength--;
+
                 if (expectedQueueLength < 0) {
                     return;
                 }
@@ -331,7 +333,6 @@ describe('queue', function () {
 
             // Should synchronously increase queue counter
             expect(queue.getQueueLength()).to.be.eql(expectedQueueLength);
-            expectedQueueLength = expectedQueueLength - 1;
         });
 
     });

--- a/test/test.queue.js
+++ b/test/test.queue.js
@@ -253,6 +253,72 @@ describe('queue', function () {
                 })
                 .then(done, done);
         });
+
+        it('passes exceptions', function (done) {
+            var queue = new Queue();
+
+            queue
+                .add(function () {
+                    throw new Error('Caught Exception');
+                })
+                .then(function () {
+                    throw new Error('It should be rejected');
+                }, function (error) {
+                    expect(error).to.be.instanceOf(Error);
+                    expect(error.message).to.eql('Caught Exception');
+                })
+                .then(done, done);
+        });
+
+        it('passes exceptions when second item in queue', function (done) {
+            var queue = new Queue();
+
+            queue
+                .add(function () {
+                    return new vow.Promise(function (resolve, reject, notify) {
+                        setTimeout(function () {
+                            resolve();
+                        }, 0);
+                    });
+                });
+
+            queue
+                .add(function () {
+                    throw new Error('Caught Exception');
+                })
+                .then(function () {
+                    throw new Error('It should be rejected');
+                }, function (error) {
+                    expect(error).to.be.instanceOf(Error);
+                    expect(error.message).to.eql('Caught Exception');
+                })
+                .then(done, done);
+        });
+
+        it('maintains proper order with exception', function (done) {
+            var queue = new Queue();
+            var listener = sinon.spy();
+            var listener2 = sinon.spy();
+
+            queue
+                .add(function () {
+                    throw new Error('Caught Exception');
+                })
+                .then(null, listener);
+
+            queue
+                .add(function () {
+                    return new vow.Promise(function (resolve, reject, notify) {
+                        setTimeout(function () {
+                            resolve();
+                        }, 0);
+                    });
+                })
+                .then(listener)
+                .then(function() {
+                    expect(listener).to.have.been.calledBefore(listener2);
+                }).then(done, done);
+        });
     });
 
     describe('getPendingLength', function () {

--- a/test/test.queue.js
+++ b/test/test.queue.js
@@ -67,9 +67,16 @@ describe('queue export', function () {
 });
 
 describe('queue.configure()', function () {
+
     beforeEach(function () {
+        // In case Promise exists natively (nodejs > 0.11.11)
+        delete global.Promise;
         clean();
         reset();
+    });
+
+    afterEach(function () {
+        delete global.Promise;
     });
 
     it('queue.add().then() should throw an exception if queue is not configured', function () {
@@ -79,15 +86,6 @@ describe('queue.configure()', function () {
                 return vow.fulfill(true);
             }).then(function () {});
         }).to.throw(Error);
-    });
-
-    beforeEach(function () {
-        clean();
-        reset();
-    });
-
-    afterEach(function () {
-        delete global.Promise;
     });
 
     it('queue.add().then() should not throw an exception if global Promise exists', function () {
@@ -280,6 +278,7 @@ describe('queue', function () {
                     return;
                 }
                 expect(queue.getPendingLength()).to.be.eql(pendingNumber);
+
                 if (pendingNumber === 0) {
                     done();
                 }
@@ -288,7 +287,7 @@ describe('queue', function () {
             // Note: extra promises will be moved to a queue
             for (var i = 0; i < expectedPendingLength * 2; i++) {
                 // Check is after the first item is complete, so it should always be one less.
-                queue.add(generator()).then(check).then(null, done);
+                queue.add(generator()).then(check).done();
             }
 
             // Should synchronously increase pending counter
@@ -328,7 +327,7 @@ describe('queue', function () {
 
             // Note: extra promises will be moved to a queue
             for (var i = 0; i <= expectedQueueLength; i++) {
-                queue.add(generator()).then(check).then(null, done);
+                queue.add(generator()).then(check).done();
             }
 
             // Should synchronously increase queue counter


### PR DESCRIPTION
Since some promise libraries automatically convert an exception into a rejection, and because the promise returned from the queue is not the same one that is used by the queue management, it was causing the exception to be completely dropped.

First attempt to fix this was adding a second `then` handler, which worked, however caused a couple of new issues, because the rejection is handled in the calling context, the item that is rejected is the previous queue item.  Getting the next queue item looks to be complex and would potentially have issues with queues that run more than 1 item at a time.

So since promises already essentially wrap a try catch, we wrap this around the main calling stack in dequeue, this allows the exception to be handled in the same stack it was thrown in, everything gets called in the correct order.  This should mean the try/catch example in the README is no longer needed as it will handle it internally automatically and pass it to the reject, instead of only try/catching only when the queue was empty when it was added.

This should resolve the issue in #6 