### PR TITLE
Add optional onEmpty callback.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -69,7 +69,8 @@
      *     doStuffWith(file);
      * });
      */
-    function Queue(maxPendingPromises, maxQueuedPromises) {
+    function Queue(maxPendingPromises, maxQueuedPromises, options) {
+        this.options = options = options || {};
         this.pendingPromises = 0;
         this.maxPendingPromises = typeof maxPendingPromises !== 'undefined' ? maxPendingPromises : Infinity;
         this.maxQueuedPromises = typeof maxQueuedPromises !== 'undefined' ? maxQueuedPromises : Infinity;
@@ -140,6 +141,9 @@
         // Remove from queue
         var item = this.queue.shift();
         if (!item) {
+            if (this.options.onEmpty) {
+                this.options.onEmpty();
+            }
             return false;
         }
 


### PR DESCRIPTION
Adds an option so user can pass an `onEmpty` callback that gets called each time the queue empties. Useful for a global spinner in an application I'm working on right now.

No tests (yet?) since I couldn't get the current tests to pass due to this error:

```
➜  promise-queue git:(on-empty) ✗ npm test

> promise-queue@2.2.2 test /Users/anders/code/promise-queue
> make validate

./node_modules/.bin/jshint .
./node_modules/.bin/jscs .
/Users/anders/code/promise-queue/node_modules/vow-fs/lib/fs.js:152
            var promise = Vow.promise();
                              ^

TypeError: Vow.promise is not a function
    at Object.exists (/Users/anders/code/promise-queue/node_modules/vow-fs/lib/fs.js:152:31)
    at Object.Checker.checkPath (/Users/anders/code/promise-queue/node_modules/jscs/lib/checker.js:204:22)
    at /Users/anders/code/promise-queue/node_modules/jscs/lib/cli.js:39:28
    at Array.map (native)
    at Object.<anonymous> (/Users/anders/code/promise-queue/node_modules/jscs/lib/cli.js:38:30)
    at Module._compile (module.js:435:26)
    at Object.Module._extensions..js (module.js:442:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Module.require (module.js:366:17)
make: *** [lint] Error 1
npm ERR! Test failed.  See above for more details.
```
